### PR TITLE
Fix export image compression

### DIFF
--- a/veusz/document/export.py
+++ b/veusz/document/export.py
@@ -226,8 +226,12 @@ class Export(object):
         except TypeError:
             return self.pagenumber
 
-    def exportBitmap(self, format):
+    def exportBitmap(self, ext):
         """Export to a bitmap format."""
+
+        format = ext[1:] # setFormat() doesn't want the leading '.'
+        if format == 'jpeg':
+            format = 'jpg'
 
         page = self.getSinglePage()
 
@@ -237,7 +241,7 @@ class Export(object):
 
         # create real output image
         backqcolor = utils.extendedColorToQColor(self.backcolor)
-        if format == '.png':
+        if format == 'png':
             # transparent output
             image = qt4.QImage(size[0], size[1],
                                qt4.QImage.Format_ARGB32_Premultiplied)
@@ -262,8 +266,7 @@ class Export(object):
 
         # write image to disk
         writer = qt4.QImageWriter()
-        # format below takes extension without dot
-        writer.setFormat(qt4.QByteArray(format[1:]))
+        writer.setFormat(qt4.QByteArray(format))
         writer.setFileName(self.filename)
 
         if format == 'png':

--- a/veusz/document/export.py
+++ b/veusz/document/export.py
@@ -269,6 +269,17 @@ class Export(object):
         writer.setFormat(qt4.QByteArray(format))
         writer.setFileName(self.filename)
 
+        # enable LZW compression for TIFFs
+        writer.setCompression(1)
+
+        try:
+            # try to enable optimal JPEG compression using new
+            # options added in Qt 5.5
+            writer.setOptimizedWrite(True)
+            writer.setProgressiveScanWrite(True)
+        except AttributeError:
+            pass
+
         if format == 'png':
             # min quality for png as it makes no difference to output
             # and makes file size smaller


### PR DESCRIPTION
This branch fixes image compression for PNG export (which has been broken since at least 9f0810c992 in 2011) and also enables LZW compression for TIFF export.

Using 300 DPI exports of `broken_axis.vsz` to test:

Format | Before | After
---------  | ------------:| --------:
PNG     | 7822679 | 210885
TIFF     | 7808954 | 311248
