### PR TITLE
Make _linearInterpolWarning vals argument iterable

### DIFF
--- a/veusz/widgets/axisfunction.py
+++ b/veusz/widgets/axisfunction.py
@@ -508,6 +508,8 @@ class AxisFunction(axis.Axis):
 
     def _linearInterpolWarning(self, vals, xcoords, ycoords):
         '''Linear interpolation, giving out of bounds warning.'''
+        if not vals.shape:
+            vals=N.array([vals])
         if any(vals < xcoords[0]) or any(vals > xcoords[-1]):
             self.document.log(
                 _('Warning: values exceed bounds in axis-function'))


### PR DESCRIPTION
A non-iterable is passed to _linearInterpolWarning during updateControlItem of BoxShape if the AxisFunction is used as X/Y axis position reference (refs #123)
Made it iterable if its shape is null.