### PR TITLE
Save crash report to file

### DIFF
--- a/ui/exceptionlist.ui
+++ b/ui/exceptionlist.ui
@@ -82,6 +82,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QPushButton" name="saveButton">
+         <property name="text">
+          <string>Save report</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="cancelButton">
          <property name="text">
           <string>&amp;Ignore this time</string>


### PR DESCRIPTION
With this commit, the user will be able to choose to save a crash report to a file, instead of sending it via email.

Our application uses Veusz and, sometimes, it crashes due to our code. So, to avoid you to receive bug reports related to our application, we added the ability to remove the "Send" button from the exception report dialog.