### PR TITLE
Allow to have plotted children of a plotter

### DIFF
--- a/veusz/widgets/plotters.py
+++ b/veusz/widgets/plotters.py
@@ -170,6 +170,10 @@ class GenericPlotter(widget.Widget):
         painter = painthelper.painter(self, posn, clip=cliprect)
         with painter:
             self.dataDraw(painter, axes, posn, cliprect)
+
+        for c in self.children:
+            c.draw(posn, painthelper, outerbounds)
+
         return posn
 
     def dataDraw(self, painter, axes, posn, cliprect):
@@ -257,7 +261,7 @@ class FreePlotter(widget.Widget):
                 return None, None
             if axes[0] is None or axes[1] is None:
                 return None, None
-            
+
             xpos = axes[0].plotterToDataCoords(posn, xplt)
             ypos = axes[1].plotterToDataCoords(posn, yplt)
         else:


### PR DESCRIPTION
At the moment, if you add a child in a plotter, it is not drawn.
With this change, children of a plotter will be drawn as well.

This is very useful to us, because we created objects related to a curve which have to be children of it.
For example we created a datapoint object used to find and describe some particular points of a curve (minimum, maximum, etc...). 

![draw_children](https://cloud.githubusercontent.com/assets/944279/12506582/5bce8a26-c0f0-11e5-94c4-c09622f8fc4a.png)
