### PR TITLE
fix typo

### DIFF
--- a/scripts/fixup_veusz_dist.sh
+++ b/scripts/fixup_veusz_dist.sh
@@ -32,4 +32,4 @@ for x in QtHelp.framework QtNetwork.framework QtOpenGL.framework QtSql.framework
     rm -rf ${distdir}/Contents/Frameworks/${x}
 done
 
-rm ${distir}/Contents/Frameworks/libQtCLucene*
+rm ${distdir}/Contents/Frameworks/libQtCLucene*


### PR DESCRIPTION
Fix a typo in the variable named `distdir`