### PR TITLE
fix various crashes with qt5

### DIFF
--- a/veusz/dialogs/export.py
+++ b/veusz/dialogs/export.py
@@ -232,7 +232,7 @@ class ExportDialog(VeuszDialog):
 
         if fd.exec_() == qt4.QDialog.Accepted:
             # convert filter to extension
-            filterused = str(fd.selectedFilter())
+            filterused = str(fd.selectedNameFilter())
             chosenext = filtertoext[filterused][0]
 
             filename = fd.selectedFiles()[0]

--- a/veusz/windows/mainwindow.py
+++ b/veusz/windows/mainwindow.py
@@ -231,13 +231,13 @@ class MainWindow(qt4.QMainWindow):
 
     def dragEnterEvent(self, event):
         """Check whether event is valid to be dropped."""
-        if (event.provides("text/uri-list") and
+        if (event.mimeData().hasUrls() and
             self._getVeuszDropFiles(event)):
             event.acceptProposedAction()
 
     def dropEvent(self, event):
         """Respond to a drop event on the current window"""
-        if event.provides("text/uri-list"):
+        if event.mimeData().hasUrls():
             files = self._getVeuszDropFiles(event)
             if files:
                 if self.document.isBlank():

--- a/veusz/windows/mainwindow.py
+++ b/veusz/windows/mainwindow.py
@@ -257,6 +257,9 @@ class MainWindow(qt4.QMainWindow):
         else:
             # get list of vsz files dropped
             urls = [u.path() for u in mime.urls()]
+            # clean list of paths on Windows systems (initial /)
+            if sys.platform.startswith('win32'):
+                urls = [u[1:] for u in urls]
             urls = [u for u in urls if os.path.splitext(u)[1] == '.vsz']
             return urls
 


### PR DESCRIPTION
selectedFilter() doesn't seem to exist in pyQt 5. Replaced by selectedNameFilter in the code. 