### PR TITLE
fix shift + scroll not handling every mouses and every trackpads

### DIFF
--- a/veusz/windows/plotwindow.py
+++ b/veusz/windows/plotwindow.py
@@ -846,7 +846,7 @@ class PlotWindow( qt4.QGraphicsView ):
                 self.sumwheeldelta -= 120
         elif event.modifiers() & qt4.Qt.ShiftModifier:
             # scroll horizontally if shift is held down
-            d = event.pixelDelta()
+            d = event.angleDelta()
             delta = d.x() if d.x() != 0 else d.y()
             scrollx = self.horizontalScrollBar()
             scrollx.setValue(scrollx.value() + delta)

--- a/veusz/windows/plotwindow.py
+++ b/veusz/windows/plotwindow.py
@@ -846,7 +846,10 @@ class PlotWindow( qt4.QGraphicsView ):
                 self.sumwheeldelta -= 120
         elif event.modifiers() & qt4.Qt.ShiftModifier:
             # scroll horizontally if shift is held down
-            d = event.angleDelta()
+            d = event.pixelDelta()
+            if d.x() == 0 and d.y() == 0:
+                # Fallback mode to angleDelta
+                d = event.angleDelta()
             delta = d.x() if d.x() != 0 else d.y()
             scrollx = self.horizontalScrollBar()
             scrollx.setValue(scrollx.value() + delta)


### PR DESCRIPTION
In the Qt5 version of Veusz, the lateral scrolling in zoomed plots is lost for some hardwares.

According to Qt doc, pixelDelta "is provided on platforms that support high-resolution pixel-based delta values, such as OS X."
On the contrary, angleDelta is always returned. 