### PR TITLE
Fix crash when trying to save an error message in the exception dialo…

### DIFF
--- a/veusz/dialogs/exceptiondialog.py
+++ b/veusz/dialogs/exceptiondialog.py
@@ -241,8 +241,8 @@ class ExceptionDialog(VeuszDialog):
 
     def saveButtonSlot(self):
         filename = qt4.QFileDialog.getSaveFileName(self, 'Save File')
-        if filename:
-            f = open(filename, 'w')
+        if filename[0]:
+            f = open(filename[0], 'w')
             f.write(createReportText(self.backtrace))
             f.close()
 


### PR DESCRIPTION
…g box.

getSaveFileName returns a tuple where the first element is the file name. This first element should be passed to the open function.